### PR TITLE
⚗️Improve CatalogAssetsService performances

### DIFF
--- a/PhotoManager/Benchmarks/PhotoManager.Benchmarks/Infrastructure/AssetRepositoryLookupBenchmarks.cs
+++ b/PhotoManager/Benchmarks/PhotoManager.Benchmarks/Infrastructure/AssetRepositoryLookupBenchmarks.cs
@@ -1,0 +1,155 @@
+namespace PhotoManager.Benchmarks.Infrastructure;
+
+[MemoryDiagnoser]
+[Orderer(SummaryOrderPolicy.FastestToSlowest)]
+[RankColumn]
+public class AssetRepositoryLookupBenchmarks
+{
+    private List<Folder> _folders = null!;
+    private List<Asset> _assets = null!;
+    private Dictionary<string, Folder> _foldersByPath = null!;
+    private Dictionary<Guid, Folder> _foldersById = null!;
+    private Dictionary<Guid, Dictionary<string, Asset>> _assetsByFolderId = null!;
+
+    private string _targetPath = null!;
+    private Guid _targetFolderId;
+    private string _targetFileName = null!;
+
+    [Params(100, 1_000, 10_000)] public int FolderCount { get; set; }
+
+    [Params(10)] public int AssetsPerFolder { get; set; }
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        _folders = new(FolderCount);
+        _foldersByPath = new(FolderCount);
+        _foldersById = new(FolderCount);
+        _assets = new(FolderCount * AssetsPerFolder);
+        _assetsByFolderId = new(FolderCount);
+
+        for (int i = 0; i < FolderCount; i++)
+        {
+            Folder folder = new() { Id = Guid.NewGuid(), Path = $@"C:\Photos\Folder{i}" };
+            _folders.Add(folder);
+            _foldersByPath[folder.Path] = folder;
+            _foldersById[folder.Id] = folder;
+
+            Dictionary<string, Asset> folderAssets = new(AssetsPerFolder);
+            _assetsByFolderId[folder.Id] = folderAssets;
+
+            for (int j = 0; j < AssetsPerFolder; j++)
+            {
+                Asset asset = new()
+                {
+                    FolderId = folder.Id,
+                    Folder = folder,
+                    FileName = $"Image_{j}.jpg",
+                    Pixel = new()
+                    {
+                        Asset = new() { Width = 1920, Height = 1080 },
+                        Thumbnail = new() { Width = 200, Height = 150 }
+                    },
+                    Hash = "abc123"
+                };
+
+                _assets.Add(asset);
+                folderAssets[asset.FileName] = asset;
+            }
+        }
+
+        int targetIndex = FolderCount / 2;
+        _targetPath = _folders[targetIndex].Path;
+        _targetFolderId = _folders[targetIndex].Id;
+        _targetFileName = "Image_5.jpg";
+    }
+
+    #region GetFolderByPath
+
+    [Benchmark(Baseline = true)]
+    public Folder? GetFolderByPath_List()
+    {
+        return _folders.FirstOrDefault(f => f.Path == _targetPath);
+    }
+
+    [Benchmark]
+    public Folder? GetFolderByPath_Dictionary()
+    {
+        return _foldersByPath.GetValueOrDefault(_targetPath);
+    }
+
+    #endregion
+
+    #region FolderExists
+
+    [Benchmark]
+    public bool FolderExists_List()
+    {
+        return _folders.Any(f => f.Path == _targetPath);
+    }
+
+    [Benchmark]
+    public bool FolderExists_Dictionary()
+    {
+        return _foldersByPath.ContainsKey(_targetPath);
+    }
+
+    #endregion
+
+    #region GetFolderById
+
+    [Benchmark]
+    public Folder? GetFolderById_List()
+    {
+        return _folders.FirstOrDefault(f => f.Id == _targetFolderId);
+    }
+
+    [Benchmark]
+    public Folder? GetFolderById_Dictionary()
+    {
+        return _foldersById.GetValueOrDefault(_targetFolderId);
+    }
+
+    #endregion
+
+    #region GetAssetByFolderIdAndFileName
+
+    [Benchmark]
+    public Asset? GetAssetByFolderIdAndFileName_List()
+    {
+        return _assets.FirstOrDefault(a => a.FolderId == _targetFolderId && a.FileName == _targetFileName);
+    }
+
+    [Benchmark]
+    public Asset? GetAssetByFolderIdAndFileName_Dictionary()
+    {
+        if (_assetsByFolderId.TryGetValue(
+                _targetFolderId, out Dictionary<string, Asset>? folderAssets))
+        {
+            return folderAssets.GetValueOrDefault(_targetFileName);
+        }
+
+        return null;
+    }
+
+    #endregion
+
+    #region GetAssetsByFolderId
+
+    [Benchmark]
+    public List<Asset> GetAssetsByFolderId_List()
+    {
+        return [.. _assets.Where(a => a.FolderId == _targetFolderId)];
+    }
+
+    [Benchmark]
+    public List<Asset> GetAssetsByFolderId_Dictionary()
+    {
+        return _assetsByFolderId.TryGetValue(
+            _targetFolderId, out Dictionary<string, Asset>? folderAssets)
+            ? [.. folderAssets.Values]
+            : [];
+    }
+
+    #endregion
+}

--- a/PhotoManager/PhotoManager.Domain/AssetCreationService.cs
+++ b/PhotoManager/PhotoManager.Domain/AssetCreationService.cs
@@ -12,7 +12,8 @@ public class AssetCreationService(
     ILogger<AssetCreationService> logger)
     : IAssetCreationService
 {
-    public Asset? CreateAsset(string directoryName, string fileName, bool isVideo = false)
+    public Asset? CreateAsset(string directoryName, string fileName, bool isVideo = false,
+        bool skipCatalogCheck = false)
     {
         try
         {
@@ -38,7 +39,7 @@ public class AssetCreationService(
                 return null;
             }
 
-            if (assetRepository.IsAssetCatalogued(directoryName, fileName))
+            if (!skipCatalogCheck && assetRepository.IsAssetCatalogued(directoryName, fileName))
             {
                 return null;
             }

--- a/PhotoManager/PhotoManager.Domain/CatalogAssetsService.cs
+++ b/PhotoManager/PhotoManager.Domain/CatalogAssetsService.cs
@@ -212,8 +212,6 @@ public sealed class CatalogAssetsService : ICatalogAssetsService, IDisposable
         ref int cataloguedAssetsBatchCount, int batchSize, HashSet<string> visitedDirectories,
         CancellationToken token = default)
     {
-        Folder? folder;
-
         token.ThrowIfCancellationRequested();
 
         if (cataloguedAssetsBatchCount >= batchSize)
@@ -221,7 +219,9 @@ public sealed class CatalogAssetsService : ICatalogAssetsService, IDisposable
             return;
         }
 
-        if (!_assetRepository.FolderExists(directory))
+        Folder? folder = _assetRepository.GetFolderByPath(directory);
+
+        if (folder == null)
         {
             folder = _assetRepository.AddFolder(directory);
 
@@ -232,8 +232,6 @@ public sealed class CatalogAssetsService : ICatalogAssetsService, IDisposable
                 Message = $"Folder {directory} added to catalog."
             });
         }
-
-        folder = _assetRepository.GetFolderByPath(directory);
 
         callback(new()
         {
@@ -255,8 +253,8 @@ public sealed class CatalogAssetsService : ICatalogAssetsService, IDisposable
 
         CatalogDeletedAssets(directory, callback, ref cataloguedAssetsBatchCount, batchSize, deletedFileNames, token);
 
-        // folder is guaranteed non-null at this point (just assigned via AddFolder or GetFolderByPath on a known-existing path)
-        bool isBlobFileExists = _assetRepository.IsBlobFileExists(folder!.BlobFileName);
+        // folder is guaranteed non-null (assigned via AddFolder or GetFolderByPath on a known-existing path)
+        bool isBlobFileExists = _assetRepository.IsBlobFileExists(folder.BlobFileName);
 
         if (_assetRepository.HasChanges() || !isBlobFileExists)
         {
@@ -371,7 +369,9 @@ public sealed class CatalogAssetsService : ICatalogAssetsService, IDisposable
                 break;
             }
 
-            Asset? newAsset = _assetCreationService.CreateAsset(directory, fileName, isAssetVideo);
+            string fullPath = Path.Combine(directory, fileName);
+            Asset? newAsset = _assetCreationService.CreateAsset(directory, fileName, isAssetVideo,
+                skipCatalogCheck: true);
 
             if (newAsset == null)
             {
@@ -381,7 +381,7 @@ public sealed class CatalogAssetsService : ICatalogAssetsService, IDisposable
                     {
                         CataloguedAssetsByPath = [.. _cataloguedAssetsByPath],
                         Reason = CatalogChangeReason.AssetNotCreated,
-                        Message = $"Image {Path.Combine(directory, fileName)} not added to catalog (corrupted)."
+                        Message = $"Image {fullPath} not added to catalog (corrupted)."
                     });
                 }
 
@@ -395,7 +395,7 @@ public sealed class CatalogAssetsService : ICatalogAssetsService, IDisposable
                 Asset = newAsset,
                 CataloguedAssetsByPath = [.. _cataloguedAssetsByPath],
                 Reason = CatalogChangeReason.AssetCreated,
-                Message = $"Image {Path.Combine(directory, newAsset.FileName)} added to catalog."
+                Message = $"Image {fullPath} added to catalog."
             });
 
             _backupHasSameContent = false;
@@ -416,11 +416,14 @@ public sealed class CatalogAssetsService : ICatalogAssetsService, IDisposable
                 break;
             }
 
+            string fullPath = Path.Combine(directory, fileName);
+
             Asset? deletedAsset = _assetRepository.DeleteAsset(directory, fileName);
             _cataloguedAssetsByPath.RemoveAll(a => a.FileName == fileName);
             _backupHasSameContent = false;
 
-            Asset? updatedAsset = _assetCreationService.CreateAsset(directory, fileName);
+            Asset? updatedAsset = _assetCreationService.CreateAsset(directory, fileName,
+                skipCatalogCheck: true);
 
             if (updatedAsset == null)
             {
@@ -429,7 +432,7 @@ public sealed class CatalogAssetsService : ICatalogAssetsService, IDisposable
                     Asset = deletedAsset,
                     CataloguedAssetsByPath = [.. _cataloguedAssetsByPath],
                     Reason = CatalogChangeReason.AssetDeleted,
-                    Message = $"Image {Path.Combine(directory, fileName)} deleted from catalog (corrupted)."
+                    Message = $"Image {fullPath} deleted from catalog (corrupted)."
                 });
 
                 continue;
@@ -437,7 +440,6 @@ public sealed class CatalogAssetsService : ICatalogAssetsService, IDisposable
 
             _cataloguedAssetsByPath.Add(updatedAsset);
 
-            string fullPath = Path.Combine(directory, fileName);
             callback(new()
             {
                 Asset = updatedAsset,
@@ -463,6 +465,8 @@ public sealed class CatalogAssetsService : ICatalogAssetsService, IDisposable
                 break;
             }
 
+            string fullPath = Path.Combine(directory, fileName);
+
             Asset? deletedAsset = _assetRepository.DeleteAsset(directory, fileName);
             _cataloguedAssetsByPath.RemoveAll(a => a.FileName == fileName);
 
@@ -471,7 +475,7 @@ public sealed class CatalogAssetsService : ICatalogAssetsService, IDisposable
                 Asset = deletedAsset,
                 CataloguedAssetsByPath = [.. _cataloguedAssetsByPath],
                 Reason = CatalogChangeReason.AssetDeleted,
-                Message = $"Image {Path.Combine(directory, fileName)} deleted from catalog."
+                Message = $"Image {fullPath} deleted from catalog."
             });
 
             _backupHasSameContent = false;

--- a/PhotoManager/PhotoManager.Domain/CatalogAssetsService.cs
+++ b/PhotoManager/PhotoManager.Domain/CatalogAssetsService.cs
@@ -17,6 +17,7 @@ public sealed class CatalogAssetsService : ICatalogAssetsService, IDisposable
     private readonly HashSet<string> _directories = [];
     private List<Asset> _cataloguedAssetsByPath = [];
     private readonly IDisposable _assetsUpdatedSubscription;
+    private bool _suppressReactiveUpdates;
 
     public CatalogAssetsService(
         IAssetRepository assetRepository,
@@ -45,6 +46,11 @@ public sealed class CatalogAssetsService : ICatalogAssetsService, IDisposable
 
     private void UpdateAssets()
     {
+        if (_suppressReactiveUpdates)
+        {
+            return;
+        }
+
         _cataloguedAssetsByPath = _assetRepository.GetCataloguedAssetsByPath(_currentFolderPath);
     }
 
@@ -54,6 +60,8 @@ public sealed class CatalogAssetsService : ICatalogAssetsService, IDisposable
         {
             int cataloguedAssetsBatchCount = 0;
             HashSet<string> visitedDirectories = [];
+
+            _suppressReactiveUpdates = true;
 
             try
             {
@@ -151,6 +159,8 @@ public sealed class CatalogAssetsService : ICatalogAssetsService, IDisposable
             }
             finally
             {
+                _suppressReactiveUpdates = false;
+
                 callback(new()
                 {
                     Reason = CatalogChangeReason.CatalogProcessEnded,
@@ -182,7 +192,8 @@ public sealed class CatalogAssetsService : ICatalogAssetsService, IDisposable
     {
         int batchSize = _userConfigurationService.AssetSettings.CatalogBatchSize;
         _currentFolderPath = directory;
-        UpdateAssets(); // Needed when having multiple actions on the same instance
+        // Explicit refresh for the new folder (not suppressed by the reactive guard)
+        _cataloguedAssetsByPath = _assetRepository.GetCataloguedAssetsByPath(_currentFolderPath);
 
         if (_fileOperationsService.FolderExists(directory))
         {
@@ -286,7 +297,9 @@ public sealed class CatalogAssetsService : ICatalogAssetsService, IDisposable
         // If the directory has been manually deleted during the EnumerateDirectories, we want to throw an exception
         Folder folder = _assetRepository.GetFolderByPath(directory)!;
 
-        foreach (Asset asset in _cataloguedAssetsByPath)
+        List<Asset> assetsToProcess = [.. _cataloguedAssetsByPath];
+
+        foreach (Asset asset in assetsToProcess)
         {
             token.ThrowIfCancellationRequested();
 
@@ -296,13 +309,14 @@ public sealed class CatalogAssetsService : ICatalogAssetsService, IDisposable
             }
 
             _ = _assetRepository.DeleteAsset(directory, asset.FileName);
+            _cataloguedAssetsByPath.Remove(asset);
             _backupHasSameContent = false;
             cataloguedAssetsBatchCount++;
 
             callback(new()
             {
                 Asset = asset,
-                CataloguedAssetsByPath = _cataloguedAssetsByPath,
+                CataloguedAssetsByPath = [.. _cataloguedAssetsByPath],
                 Reason = CatalogChangeReason.AssetDeleted,
                 Message = $"Image {Path.Combine(directory, asset.FileName)} deleted from catalog."
             });
@@ -365,7 +379,7 @@ public sealed class CatalogAssetsService : ICatalogAssetsService, IDisposable
                 {
                     callback(new()
                     {
-                        CataloguedAssetsByPath = _cataloguedAssetsByPath,
+                        CataloguedAssetsByPath = [.. _cataloguedAssetsByPath],
                         Reason = CatalogChangeReason.AssetNotCreated,
                         Message = $"Image {Path.Combine(directory, fileName)} not added to catalog (corrupted)."
                     });
@@ -374,10 +388,12 @@ public sealed class CatalogAssetsService : ICatalogAssetsService, IDisposable
                 continue;
             }
 
+            _cataloguedAssetsByPath.Add(newAsset);
+
             callback(new()
             {
                 Asset = newAsset,
-                CataloguedAssetsByPath = _cataloguedAssetsByPath,
+                CataloguedAssetsByPath = [.. _cataloguedAssetsByPath],
                 Reason = CatalogChangeReason.AssetCreated,
                 Message = $"Image {Path.Combine(directory, newAsset.FileName)} added to catalog."
             });
@@ -401,6 +417,7 @@ public sealed class CatalogAssetsService : ICatalogAssetsService, IDisposable
             }
 
             Asset? deletedAsset = _assetRepository.DeleteAsset(directory, fileName);
+            _cataloguedAssetsByPath.RemoveAll(a => a.FileName == fileName);
             _backupHasSameContent = false;
 
             Asset? updatedAsset = _assetCreationService.CreateAsset(directory, fileName);
@@ -410,7 +427,7 @@ public sealed class CatalogAssetsService : ICatalogAssetsService, IDisposable
                 callback(new()
                 {
                     Asset = deletedAsset,
-                    CataloguedAssetsByPath = _cataloguedAssetsByPath,
+                    CataloguedAssetsByPath = [.. _cataloguedAssetsByPath],
                     Reason = CatalogChangeReason.AssetDeleted,
                     Message = $"Image {Path.Combine(directory, fileName)} deleted from catalog (corrupted)."
                 });
@@ -418,11 +435,13 @@ public sealed class CatalogAssetsService : ICatalogAssetsService, IDisposable
                 continue;
             }
 
+            _cataloguedAssetsByPath.Add(updatedAsset);
+
             string fullPath = Path.Combine(directory, fileName);
             callback(new()
             {
                 Asset = updatedAsset,
-                CataloguedAssetsByPath = _cataloguedAssetsByPath,
+                CataloguedAssetsByPath = [.. _cataloguedAssetsByPath],
                 Reason = CatalogChangeReason.AssetUpdated,
                 Message = $"Image {fullPath} updated in catalog."
             });
@@ -445,11 +464,12 @@ public sealed class CatalogAssetsService : ICatalogAssetsService, IDisposable
             }
 
             Asset? deletedAsset = _assetRepository.DeleteAsset(directory, fileName);
+            _cataloguedAssetsByPath.RemoveAll(a => a.FileName == fileName);
 
             callback(new()
             {
                 Asset = deletedAsset,
-                CataloguedAssetsByPath = _cataloguedAssetsByPath,
+                CataloguedAssetsByPath = [.. _cataloguedAssetsByPath],
                 Reason = CatalogChangeReason.AssetDeleted,
                 Message = $"Image {Path.Combine(directory, fileName)} deleted from catalog."
             });

--- a/PhotoManager/PhotoManager.Domain/Interfaces/IAssetCreationService.cs
+++ b/PhotoManager/PhotoManager.Domain/Interfaces/IAssetCreationService.cs
@@ -2,5 +2,5 @@
 
 public interface IAssetCreationService
 {
-    Asset? CreateAsset(string directoryName, string fileName, bool isVideo = false);
+    Asset? CreateAsset(string directoryName, string fileName, bool isVideo = false, bool skipCatalogCheck = false);
 }

--- a/PhotoManager/PhotoManager.Infrastructure/AssetRepository.cs
+++ b/PhotoManager/PhotoManager.Infrastructure/AssetRepository.cs
@@ -19,6 +19,9 @@ public class AssetRepository : IAssetRepository
 
     private List<Asset> _assets;
     private List<Folder> _folders;
+    private readonly Dictionary<string, Folder> _foldersByPath = [];
+    private readonly Dictionary<Guid, Folder> _foldersById = [];
+    private readonly Dictionary<Guid, Dictionary<string, Asset>> _assetsByFolderId = [];
     private SyncAssetsConfiguration _syncAssetsConfiguration;
     private List<string> _recentTargetPaths;
     protected Dictionary<string, Dictionary<string, byte[]>> Thumbnails { get; }
@@ -134,6 +137,14 @@ public class AssetRepository : IAssetRepository
                 {
                     folderThumbnails[asset.FileName] = thumbnailData;
                     _assets.Add(asset);
+
+                    if (!_assetsByFolderId.TryGetValue(asset.FolderId, out Dictionary<string, Asset>? assetsByName))
+                    {
+                        assetsByName = [];
+                        _assetsByFolderId[asset.FolderId] = assetsByName;
+                    }
+
+                    assetsByName[asset.FileName] = asset;
                     _hasChanges = true;
                     _assetsUpdatedSubject.OnNext(Unit.Default);
                 }
@@ -164,6 +175,8 @@ public class AssetRepository : IAssetRepository
             };
 
             _folders.Add(folder);
+            _foldersByPath.TryAdd(folder.Path, folder);
+            _foldersById[folder.Id] = folder;
             _hasChanges = true;
         }
 
@@ -176,7 +189,7 @@ public class AssetRepository : IAssetRepository
 
         lock (_syncLock)
         {
-            result = _folders.Any(f => f.Path == path);
+            result = _foldersByPath.ContainsKey(path);
         }
 
         return result;
@@ -218,7 +231,7 @@ public class AssetRepository : IAssetRepository
 
         lock (_syncLock)
         {
-            result = _folders.FirstOrDefault(f => f.Path == path);
+            result = _foldersByPath.GetValueOrDefault(path);
         }
 
         return result;
@@ -301,9 +314,11 @@ public class AssetRepository : IAssetRepository
         {
             Folder? folder = GetFolderByPath(directory);
 
-            if (folder != null)
+            if (folder != null
+                && _assetsByFolderId.TryGetValue(
+                    folder.Id, out Dictionary<string, Asset>? folderAssets))
             {
-                cataloguedAssets = [.. _assets.Where(a => a.FolderId == folder.Id)];
+                cataloguedAssets = [.. folderAssets.Values];
             }
         }
 
@@ -356,6 +371,17 @@ public class AssetRepository : IAssetRepository
                 if (assetToDelete != null)
                 {
                     _assets.Remove(assetToDelete);
+
+                    if (_assetsByFolderId.TryGetValue(folder.Id, out Dictionary<string, Asset>? assetsByName))
+                    {
+                        assetsByName.Remove(fileName);
+
+                        if (assetsByName.Count == 0)
+                        {
+                            _assetsByFolderId.Remove(folder.Id);
+                        }
+                    }
+
                     _hasChanges = true;
                     _assetsUpdatedSubject.OnNext(Unit.Default);
                 }
@@ -384,6 +410,13 @@ public class AssetRepository : IAssetRepository
                 }
 
                 _folders.Remove(folder);
+
+                if (_foldersByPath.TryGetValue(folder.Path, out Folder? indexed) && indexed.Id == folder.Id)
+                {
+                    _foldersByPath.Remove(folder.Path);
+                }
+
+                _foldersById.Remove(folder.Id);
                 _hasChanges = true;
             }
         }
@@ -592,6 +625,9 @@ public class AssetRepository : IAssetRepository
         {
             _assets = ReadAssets();
             _folders = ReadFolders();
+
+            BuildIndexes();
+
             _syncAssetsConfiguration.Definitions.AddRange(ReadSyncAssetsDirectoriesDefinitions());
             _recentTargetPaths = ReadRecentTargetPaths();
 
@@ -609,6 +645,31 @@ public class AssetRepository : IAssetRepository
         {
             _logger.LogError(ex, "Error reading catalog");
             throw;
+        }
+    }
+
+    private void BuildIndexes()
+    {
+        _foldersByPath.Clear();
+        _foldersById.Clear();
+        _assetsByFolderId.Clear();
+
+        foreach (Folder folder in _folders)
+        {
+            _foldersByPath.TryAdd(folder.Path, folder);
+            _foldersById.TryAdd(folder.Id, folder);
+        }
+
+        foreach (Asset asset in _assets)
+        {
+            if (!_assetsByFolderId.TryGetValue(
+                    asset.FolderId, out Dictionary<string, Asset>? folderAssets))
+            {
+                folderAssets = [];
+                _assetsByFolderId[asset.FolderId] = folderAssets;
+            }
+
+            folderAssets.TryAdd(asset.FileName, asset);
         }
     }
 
@@ -726,7 +787,7 @@ public class AssetRepository : IAssetRepository
 
         lock (_syncLock)
         {
-            result = _folders.FirstOrDefault(f => f.Id == folderId);
+            result = _foldersById.GetValueOrDefault(folderId);
         }
 
         return result;
@@ -738,7 +799,9 @@ public class AssetRepository : IAssetRepository
 
         lock (_syncLock)
         {
-            result = [.. _assets.Where(a => a.FolderId == folderId)];
+            result = _assetsByFolderId.TryGetValue(folderId, out Dictionary<string, Asset>? folderAssets)
+                ? [.. folderAssets.Values]
+                : [];
         }
 
         return result;
@@ -746,11 +809,14 @@ public class AssetRepository : IAssetRepository
 
     private Asset? GetAssetByFolderIdAndFileName(Guid folderId, string fileName)
     {
-        Asset? asset;
+        Asset? asset = null;
 
         lock (_syncLock)
         {
-            asset = _assets.FirstOrDefault(a => a.FolderId == folderId && a.FileName == fileName);
+            if (_assetsByFolderId.TryGetValue(folderId, out Dictionary<string, Asset>? folderAssets))
+            {
+                asset = folderAssets.GetValueOrDefault(fileName);
+            }
         }
 
         return asset;

--- a/PhotoManager/PhotoManager.Tests/Integration/Application/ApplicationGetAssetsByPathTests.cs
+++ b/PhotoManager/PhotoManager.Tests/Integration/Application/ApplicationGetAssetsByPathTests.cs
@@ -714,9 +714,9 @@ public class ApplicationGetAssetsByPathTests
 
         try
         {
-            if (folderExists)
+            if (folderExists && directory != null)
             {
-                _testableAssetRepository!.AddFolder(directory!);
+                _testableAssetRepository!.AddFolder(directory);
             }
 
             ArgumentException? exception =

--- a/PhotoManager/PhotoManager.Tests/Integration/Domain/AssetCreationServiceTests.cs
+++ b/PhotoManager/PhotoManager.Tests/Integration/Domain/AssetCreationServiceTests.cs
@@ -1642,6 +1642,211 @@ public class AssetCreationServiceTests
     }
 
     [Test]
+    public void
+        CreateAsset_PictureAndBasicHashTypeAndCreatingTwiceSameImageAndSkipCatalogCheckFalse_DoesNotAddTheSecondOneAndReturnsNull()
+    {
+        ConfigureAssetCreationService(200, 150, false, false, false, false);
+
+        Asset expectedAsset = new()
+        {
+            FolderId = Guid.Empty, // Initialised later
+            Folder = new() { Id = Guid.Empty, Path = "" }, // Initialised later
+            FileName = FileNames.IMAGE_1_JPG,
+            Pixel = new()
+            {
+                Asset = new() { Width = PixelWidthAsset.IMAGE_1_JPG, Height = PixelHeightAsset.IMAGE_1_JPG },
+                Thumbnail = new() { Width = ThumbnailWidthAsset.IMAGE_1_JPG, Height = ThumbnailHeightAsset.IMAGE_1_JPG }
+            },
+            FileProperties = new()
+            {
+                Size = FileSize.IMAGE_1_JPG,
+                Creation = DateTime.Now,
+                Modification = ModificationDate.Default
+            },
+            ThumbnailCreationDateTime = DateTime.Now,
+            ImageRotation = Rotation.Rotate0,
+            Hash = Hashes.IMAGE_1_JPG,
+            Metadata = new()
+            {
+                Corrupted = new() { IsTrue = false, Message = null },
+                Rotated = new() { IsTrue = false, Message = null }
+            }
+        };
+
+        const int imageByteSize = ImageByteSizes.IMAGE_1_JPG;
+
+        try
+        {
+            Folder folder = _testableAssetRepository!.AddFolder(_dataDirectory!); // Set above, not in this method
+
+            string imagePath = Path.Combine(_dataDirectory!, FileNames.IMAGE_1_JPG);
+            Assert.That(File.Exists(imagePath), Is.True);
+
+            List<Asset> assetsFromRepository = _testableAssetRepository.GetCataloguedAssets();
+            Assert.That(assetsFromRepository, Is.Empty);
+
+            Dictionary<string, Dictionary<string, byte[]>> thumbnails = _testableAssetRepository!.GetThumbnails();
+            Assert.That(thumbnails, Is.Empty);
+
+            Asset? asset = _assetCreationService!.CreateAsset(_dataDirectory!, FileNames.IMAGE_1_JPG,
+                skipCatalogCheck: false);
+
+            Assert.That(asset, Is.Not.Null);
+
+            AssertAssetPropertyValidity(
+                asset!,
+                expectedAsset.FileName,
+                imagePath,
+                _dataDirectory!,
+                folder,
+                expectedAsset.FileProperties.Size,
+                expectedAsset.Pixel.Asset.Width,
+                expectedAsset.Pixel.Asset.Height,
+                expectedAsset.Pixel.Thumbnail.Width,
+                expectedAsset.Pixel.Thumbnail.Height,
+                expectedAsset.FileProperties.Modification,
+                expectedAsset.ImageRotation,
+                expectedAsset.Hash,
+                expectedAsset.Metadata.Corrupted.IsTrue,
+                expectedAsset.Metadata.Corrupted.Message,
+                expectedAsset.Metadata.Rotated.IsTrue,
+                expectedAsset.Metadata.Rotated.Message);
+
+            AssertCataloguedAssetAndThumbnailValidity(asset!, folder, thumbnails, imageByteSize);
+
+            Asset? newSameAsset = _assetCreationService!.CreateAsset(_dataDirectory!, FileNames.IMAGE_1_JPG,
+                skipCatalogCheck: false);
+
+            Assert.That(newSameAsset, Is.Null);
+
+            AssertCataloguedAssetAndThumbnailValidity(asset!, folder, thumbnails, imageByteSize);
+
+            _testLogger!.AssertLogExceptions([], typeof(AssetCreationService));
+        }
+        finally
+        {
+            Directory.Delete(_databaseDirectory!, true);
+        }
+    }
+
+    [Test]
+    public void
+        CreateAsset_PictureAndBasicHashTypeAndCreatingTwiceSameImageAndSkipCatalogCheckTrue_ReturnsAssetBothTimes()
+    {
+        ConfigureAssetCreationService(200, 150, false, false, false, false);
+
+        Asset expectedAsset = new()
+        {
+            FolderId = Guid.Empty, // Initialised later
+            Folder = new() { Id = Guid.Empty, Path = "" }, // Initialised later
+            FileName = FileNames.IMAGE_1_JPG,
+            Pixel = new()
+            {
+                Asset = new() { Width = PixelWidthAsset.IMAGE_1_JPG, Height = PixelHeightAsset.IMAGE_1_JPG },
+                Thumbnail = new() { Width = ThumbnailWidthAsset.IMAGE_1_JPG, Height = ThumbnailHeightAsset.IMAGE_1_JPG }
+            },
+            FileProperties = new()
+            {
+                Size = FileSize.IMAGE_1_JPG,
+                Creation = DateTime.Now,
+                Modification = ModificationDate.Default
+            },
+            ThumbnailCreationDateTime = DateTime.Now,
+            ImageRotation = Rotation.Rotate0,
+            Hash = Hashes.IMAGE_1_JPG,
+            Metadata = new()
+            {
+                Corrupted = new() { IsTrue = false, Message = null },
+                Rotated = new() { IsTrue = false, Message = null }
+            }
+        };
+
+        const int imageByteSize = ImageByteSizes.IMAGE_1_JPG;
+
+        try
+        {
+            Folder folder = _testableAssetRepository!.AddFolder(_dataDirectory!); // Set above, not in this method
+
+            string imagePath = Path.Combine(_dataDirectory!, FileNames.IMAGE_1_JPG);
+            Assert.That(File.Exists(imagePath), Is.True);
+
+            List<Asset> assetsFromRepository = _testableAssetRepository.GetCataloguedAssets();
+            Assert.That(assetsFromRepository, Is.Empty);
+
+            Dictionary<string, Dictionary<string, byte[]>> thumbnails = _testableAssetRepository!.GetThumbnails();
+            Assert.That(thumbnails, Is.Empty);
+
+            Asset? asset = _assetCreationService!.CreateAsset(_dataDirectory!, FileNames.IMAGE_1_JPG,
+                skipCatalogCheck: true);
+
+            Assert.That(asset, Is.Not.Null);
+
+            AssertAssetPropertyValidity(
+                asset!,
+                expectedAsset.FileName,
+                imagePath,
+                _dataDirectory!,
+                folder,
+                expectedAsset.FileProperties.Size,
+                expectedAsset.Pixel.Asset.Width,
+                expectedAsset.Pixel.Asset.Height,
+                expectedAsset.Pixel.Thumbnail.Width,
+                expectedAsset.Pixel.Thumbnail.Height,
+                expectedAsset.FileProperties.Modification,
+                expectedAsset.ImageRotation,
+                expectedAsset.Hash,
+                expectedAsset.Metadata.Corrupted.IsTrue,
+                expectedAsset.Metadata.Corrupted.Message,
+                expectedAsset.Metadata.Rotated.IsTrue,
+                expectedAsset.Metadata.Rotated.Message);
+
+            AssertCataloguedAssetAndThumbnailValidity(asset!, folder, thumbnails, imageByteSize);
+
+            Asset? newSameAsset = _assetCreationService!.CreateAsset(_dataDirectory!, FileNames.IMAGE_1_JPG,
+                skipCatalogCheck: true);
+
+            Assert.That(newSameAsset, Is.Not.Null);
+
+            AssertAssetPropertyValidity(
+                newSameAsset!,
+                expectedAsset.FileName,
+                imagePath,
+                _dataDirectory!,
+                folder,
+                expectedAsset.FileProperties.Size,
+                expectedAsset.Pixel.Asset.Width,
+                expectedAsset.Pixel.Asset.Height,
+                expectedAsset.Pixel.Thumbnail.Width,
+                expectedAsset.Pixel.Thumbnail.Height,
+                expectedAsset.FileProperties.Modification,
+                expectedAsset.ImageRotation,
+                expectedAsset.Hash,
+                expectedAsset.Metadata.Corrupted.IsTrue,
+                expectedAsset.Metadata.Corrupted.Message,
+                expectedAsset.Metadata.Rotated.IsTrue,
+                expectedAsset.Metadata.Rotated.Message);
+
+            assetsFromRepository = _testableAssetRepository.GetCataloguedAssets();
+            Assert.That(assetsFromRepository, Has.Count.EqualTo(2));
+            Assert.That(assetsFromRepository[0].FileName, Is.EqualTo(expectedAsset.FileName));
+            Assert.That(assetsFromRepository[1].FileName, Is.EqualTo(expectedAsset.FileName));
+            Assert.That(assetsFromRepository[0].Hash, Is.EqualTo(expectedAsset.Hash));
+            Assert.That(assetsFromRepository[1].Hash, Is.EqualTo(expectedAsset.Hash));
+
+            Assert.That(thumbnails, Has.Count.EqualTo(1));
+            Assert.That(thumbnails[folder.Path], Has.Count.EqualTo(1));
+            Assert.That(thumbnails[folder.Path][expectedAsset.FileName], Is.Not.Null);
+            Assert.That(thumbnails[folder.Path][expectedAsset.FileName], Has.Length.EqualTo(imageByteSize));
+
+            _testLogger!.AssertLogExceptions([], typeof(AssetCreationService));
+        }
+        finally
+        {
+            Directory.Delete(_databaseDirectory!, true);
+        }
+    }
+
+    [Test]
     [TestCase(FileNames.IMAGE_1_JPG, "Invalid_Image_1.jpg")]
     [TestCase(FileNames.HOMER_GIF, "Invalid_Homer.gif")]
     [TestCase(FileNames.IMAGE_9_PNG, "Invalid_Image_9.png")]

--- a/PhotoManager/PhotoManager.Tests/Integration/Domain/CatalogAssets/CatalogAssetsServiceTests.cs
+++ b/PhotoManager/PhotoManager.Tests/Integration/Domain/CatalogAssets/CatalogAssetsServiceTests.cs
@@ -10330,6 +10330,7 @@ public class CatalogAssetsServiceTests
                 DisposeCheckCatalogChangesAssetAdded(
                     catalogChanges,
                     assetsDirectory,
+                    folderToAssetsMapping[folder!][..(i + 1)],
                     folderToAssetsMapping[folder!][i],
                     folder!,
                     ref increment);
@@ -10381,6 +10382,7 @@ public class CatalogAssetsServiceTests
     private static void DisposeCheckCatalogChangesAssetAdded(
         List<CatalogChangeCallbackEventArgs> catalogChanges,
         string assetsDirectory,
+        IReadOnlyList<Asset> expectedAssets,
         Asset expectedAsset,
         Folder folder,
         ref int increment)
@@ -10390,7 +10392,7 @@ public class CatalogAssetsServiceTests
         DisposeAssertAssetPropertyValidityAndImageData(catalogChange.Asset!, expectedAsset, expectedAsset.FullPath,
             assetsDirectory, folder);
         Assert.That(catalogChange.Folder, Is.Null);
-        Assert.That(catalogChange.CataloguedAssetsByPath, Is.Empty);
+        Assert.That(catalogChange.CataloguedAssetsByPath, Has.Count.EqualTo(expectedAssets.Count));
         Assert.That(catalogChange.Reason, Is.EqualTo(CatalogChangeReason.AssetCreated));
         Assert.That(catalogChange.Message, Is.EqualTo($"Image {expectedAsset.FullPath} added to catalog."));
         Assert.That(catalogChange.Exception, Is.Null);

--- a/PhotoManager/PhotoManager.Tests/Integration/Infrastructure/AssetRepositoryTests/AssetRepositoryDeleteAssetTests.cs
+++ b/PhotoManager/PhotoManager.Tests/Integration/Infrastructure/AssetRepositoryTests/AssetRepositoryDeleteAssetTests.cs
@@ -322,7 +322,7 @@ public class AssetRepositoryDeleteAssetTests
     }
 
     [Test]
-    public void DeleteAsset_DirectoryIsNull_ReturnsNullAndDoesNothingAndAssetsUpdatedIsNotUpdated()
+    public void DeleteAsset_DirectoryIsNull_LogsItAndThrowsArgumentNullExceptionAndAssetsUpdatedIsNotUpdated()
     {
         List<Reactive.Unit> assetsUpdatedEvents = [];
         IDisposable assetsUpdatedSubscription =
@@ -330,6 +330,8 @@ public class AssetRepositoryDeleteAssetTests
 
         try
         {
+            const string exceptionMessage = "Value cannot be null. (Parameter 'key')";
+
             string folderPath1 = Path.Combine(_dataDirectory!, Directories.TEST_FOLDER_1);
             string? folderPath2 = null;
 
@@ -356,9 +358,10 @@ public class AssetRepositoryDeleteAssetTests
             Assert.That(assetsUpdatedEvents, Has.Count.EqualTo(1));
             Assert.That(assetsUpdatedEvents[0], Is.EqualTo(Reactive.Unit.Default));
 
-            Asset? assetDeleted = _testableAssetRepository!.DeleteAsset(folderPath2!, _asset1.FileName);
+            ArgumentNullException? exception = Assert.Throws<ArgumentNullException>(() =>
+                _testableAssetRepository!.DeleteAsset(folderPath2!, _asset1.FileName));
 
-            Assert.That(assetDeleted, Is.Null);
+            Assert.That(exception?.Message, Is.EqualTo(exceptionMessage));
 
             Assert.That(thumbnails, Has.Count.EqualTo(1));
             Assert.That(thumbnails.ContainsKey(folderPath1), Is.True);
@@ -373,7 +376,7 @@ public class AssetRepositoryDeleteAssetTests
             Assert.That(assetsUpdatedEvents, Has.Count.EqualTo(1));
             Assert.That(assetsUpdatedEvents[0], Is.EqualTo(Reactive.Unit.Default));
 
-            _testLogger!.AssertLogExceptions([], typeof(AssetRepository));
+            _testLogger!.AssertLogExceptions([new Exception(exceptionMessage)], typeof(AssetRepository));
         }
         finally
         {

--- a/PhotoManager/PhotoManager.Tests/Integration/Infrastructure/AssetRepositoryTests/AssetRepositoryGetAssetsByPathTests.cs
+++ b/PhotoManager/PhotoManager.Tests/Integration/Infrastructure/AssetRepositoryTests/AssetRepositoryGetAssetsByPathTests.cs
@@ -799,7 +799,9 @@ public class AssetRepositoryGetAssetsByPathTests
             Assert.That(assetsUpdatedEvents, Has.Count.EqualTo(1));
             Assert.That(assetsUpdatedEvents[0], Is.EqualTo(Reactive.Unit.Default));
 
-            _testLogger!.AssertLogExceptions([], typeof(AssetRepository));
+            _testLogger!.AssertLogExceptions(
+                [new Exception("Value cannot be null. (Parameter 'key')")],
+                typeof(AssetRepository));
         }
         finally
         {

--- a/PhotoManager/PhotoManager.Tests/Integration/Infrastructure/AssetRepositoryTests/AssetRepositoryGetCataloguedAssetsByPathTests.cs
+++ b/PhotoManager/PhotoManager.Tests/Integration/Infrastructure/AssetRepositoryTests/AssetRepositoryGetCataloguedAssetsByPathTests.cs
@@ -166,13 +166,15 @@ public class AssetRepositoryGetCataloguedAssetsByPathTests
     }
 
     [Test]
-    public void GetCataloguedAssetsByPath_DirectoryIsNull_ReturnsEmptyList()
+    public void GetCataloguedAssetsByPath_DirectoryIsNull_ThrowsArgumentNullException()
     {
         List<Reactive.Unit> assetsUpdatedEvents = [];
         IDisposable assetsUpdatedSubscription = _assetRepository!.AssetsUpdated.Subscribe(assetsUpdatedEvents.Add);
 
         try
         {
+            const string exceptionMessage = "Value cannot be null. (Parameter 'key')";
+
             string folderPath1 = Path.Combine(_dataDirectory!, Directories.TEST_FOLDER_1);
             string? folderPath2 = null;
 
@@ -185,9 +187,10 @@ public class AssetRepositoryGetCataloguedAssetsByPathTests
             Assert.That(assetsUpdatedEvents, Has.Count.EqualTo(1));
             Assert.That(assetsUpdatedEvents[0], Is.EqualTo(Reactive.Unit.Default));
 
-            List<Asset> cataloguedAssets = _assetRepository.GetCataloguedAssetsByPath(folderPath2!);
+            ArgumentNullException? exception =
+                Assert.Throws<ArgumentNullException>(() => _assetRepository.GetCataloguedAssetsByPath(folderPath2!));
 
-            Assert.That(cataloguedAssets, Is.Empty);
+            Assert.That(exception?.Message, Is.EqualTo(exceptionMessage));
 
             Assert.That(assetsUpdatedEvents, Has.Count.EqualTo(1));
             Assert.That(assetsUpdatedEvents[0], Is.EqualTo(Reactive.Unit.Default));

--- a/PhotoManager/PhotoManager.Tests/Integration/Infrastructure/AssetRepositoryTests/AssetRepositoryGetFolderByPathTests.cs
+++ b/PhotoManager/PhotoManager.Tests/Integration/Infrastructure/AssetRepositoryTests/AssetRepositoryGetFolderByPathTests.cs
@@ -150,20 +150,23 @@ public class AssetRepositoryGetFolderByPathTests
     }
 
     [Test]
-    public void GetFolderByPath_PathIsNull_ReturnsNull()
+    public void GetFolderByPath_PathIsNull_ThrowsArgumentNullException()
     {
         List<Reactive.Unit> assetsUpdatedEvents = [];
         IDisposable assetsUpdatedSubscription = _assetRepository!.AssetsUpdated.Subscribe(assetsUpdatedEvents.Add);
 
         try
         {
+            const string exceptionMessage = "Value cannot be null. (Parameter 'key')";
+
             string? folderPath1 = null;
 
             _assetRepository!.AddFolder(Path.Combine(_dataDirectory!, Directories.TEST_FOLDER_1));
 
-            Folder? folderByPath1 = _assetRepository!.GetFolderByPath(folderPath1!);
+            ArgumentNullException? exception =
+                Assert.Throws<ArgumentNullException>(() => _assetRepository!.GetFolderByPath(folderPath1!));
 
-            Assert.That(folderByPath1, Is.Null);
+            Assert.That(exception?.Message, Is.EqualTo(exceptionMessage));
 
             Assert.That(assetsUpdatedEvents, Is.Empty);
 

--- a/PhotoManager/PhotoManager.Tests/Integration/Infrastructure/AssetRepositoryTests/AssetRepositoryIsAssetCataloguedTests.cs
+++ b/PhotoManager/PhotoManager.Tests/Integration/Infrastructure/AssetRepositoryTests/AssetRepositoryIsAssetCataloguedTests.cs
@@ -163,18 +163,21 @@ public class AssetRepositoryIsAssetCataloguedTests
     }
 
     [Test]
-    public void IsAssetCatalogued_DirectoryNameIsNull_ReturnsFalse()
+    public void IsAssetCatalogued_DirectoryNameIsNull_ThrowsArgumentNullException()
     {
         List<Reactive.Unit> assetsUpdatedEvents = [];
         IDisposable assetsUpdatedSubscription = _assetRepository!.AssetsUpdated.Subscribe(assetsUpdatedEvents.Add);
 
         try
         {
+            const string exceptionMessage = "Value cannot be null. (Parameter 'key')";
+
             string? folderPath = null;
 
-            bool isAssetCatalogued = _assetRepository!.IsAssetCatalogued(folderPath!, FileNames.NON_EXISTENT_FILE_JPG);
+            ArgumentNullException? exception = Assert.Throws<ArgumentNullException>(() =>
+                _assetRepository!.IsAssetCatalogued(folderPath!, FileNames.NON_EXISTENT_FILE_JPG));
 
-            Assert.That(isAssetCatalogued, Is.False);
+            Assert.That(exception?.Message, Is.EqualTo(exceptionMessage));
 
             Assert.That(assetsUpdatedEvents, Is.Empty);
 

--- a/PhotoManager/PhotoManager.Tests/PhotoManager.Tests.csproj
+++ b/PhotoManager/PhotoManager.Tests/PhotoManager.Tests.csproj
@@ -3,6 +3,13 @@
     <IsPackable>false</IsPackable>
     <Product>PhotoManager</Product>
     <FixedDate>2024-06-07T00:00:00</FixedDate>
+    <!-- Disable IDE-style code analyzers and XML doc generation for the test project.
+         In .NET 10, AnalysisLevel=latest enables significantly more IDE analyzers than .NET 8,
+         causing a ~30s overhead on every rebuild of this large test project (~200K lines).
+         Code style is still enforced via `dotnet format` in CI.
+         NUnit.Analyzers (package analyzers) are unaffected and continue to run. -->
+    <EnforceCodeStyleInBuild>false</EnforceCodeStyleInBuild>
+    <GenerateDocumentationFile>false</GenerateDocumentationFile>
   </PropertyGroup>
   <ItemGroup>
     <TestFiles Include="TestFiles\**\*.*" />

--- a/PhotoManager/PhotoManager.Tests/Unit/Domain/CatalogAssetsServiceTests.cs
+++ b/PhotoManager/PhotoManager.Tests/Unit/Domain/CatalogAssetsServiceTests.cs
@@ -152,8 +152,8 @@ public class CatalogAssetsServiceTests
 
         CatalogAssetsAsyncAsserts.CheckCatalogChangesInspectingFolder(catalogChanges, 1, foldersInRepository,
             testPath, ref increment);
-        CatalogAssetsAsyncAsserts.CheckCatalogChangesAssetAdded(catalogChanges, testPath, [], testAsset, testFolder,
-            ref increment);
+        CatalogAssetsAsyncAsserts.CheckCatalogChangesAssetAdded(catalogChanges, testPath, [testAsset], testAsset,
+            testFolder, ref increment);
         CatalogAssetsAsyncAsserts.CheckCatalogChangesCancelled(catalogChanges, ref increment);
         CatalogAssetsAsyncAsserts.CheckCatalogChangesEnd(catalogChanges, ref increment);
 

--- a/PhotoManager/PhotoManager.Tests/Unit/Domain/CatalogAssetsServiceTests.cs
+++ b/PhotoManager/PhotoManager.Tests/Unit/Domain/CatalogAssetsServiceTests.cs
@@ -92,7 +92,8 @@ public class CatalogAssetsServiceTests
         IImageMetadataService imageMetadataServiceMock = Substitute.For<IImageMetadataService>();
 
         IAssetCreationService assetCreationServiceMock = Substitute.For<IAssetCreationService>();
-        assetCreationServiceMock.CreateAsset(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<bool>()).Returns(testAsset);
+        assetCreationServiceMock.CreateAsset(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<bool>(), Arg.Any<bool>())
+            .Returns(testAsset);
 
         AssetSettings assetSettings = new(
             AnalyseVideos: false,


### PR DESCRIPTION
**AssetRepository lookup**
| Method                                   | FolderCount | AssetsPerFolder | Mean           | Error          | StdDev         | Ratio  | RatioSD | Rank | Gen0   | Allocated | Alloc Ratio |
|----------------------------------------- |------------ |---------------- |---------------:|---------------:|---------------:|-------:|--------:|-----:|-------:|----------:|------------:|
| GetFolderById_Dictionary                 | 100         | 10              |       2.524 ns |      0.0875 ns |      0.0898 ns |   0.02 |    0.00 |    1 |      - |         - |          NA |
| FolderExists_Dictionary                  | 100         | 10              |       5.131 ns |      0.1260 ns |      0.1237 ns |   0.05 |    0.00 |    2 |      - |         - |          NA |
| GetFolderByPath_Dictionary               | 100         | 10              |       8.168 ns |      0.1970 ns |      0.3603 ns |   0.07 |    0.00 |    3 |      - |         - |          NA |
| GetAssetByFolderIdAndFileName_Dictionary | 100         | 10              |      11.885 ns |      0.1585 ns |      0.1482 ns |   0.11 |    0.00 |    4 |      - |         - |          NA |
| GetFolderById_List                       | 100         | 10              |      42.608 ns |      0.7305 ns |      0.6833 ns |   0.38 |    0.01 |    5 |      - |         - |          NA |
| GetAssetsByFolderId_Dictionary           | 100         | 10              |      49.675 ns |      0.9723 ns |      0.9095 ns |   0.44 |    0.01 |    6 | 0.0108 |     136 B |          NA |
| FolderExists_List                        | 100         | 10              |     107.973 ns |      1.9388 ns |      1.8136 ns |   0.96 |    0.03 |    7 |      - |         - |          NA |
| GetFolderByPath_List                     | 100         | 10              |     112.887 ns |      2.1988 ns |      2.5322 ns |   1.00 |    0.03 |    7 |      - |         - |          NA |
| GetAssetByFolderIdAndFileName_List       | 100         | 10              |     359.674 ns |      7.0764 ns |      7.5717 ns |   3.19 |    0.09 |    8 |      - |         - |          NA |
| GetAssetsByFolderId_List                 | 100         | 10              |   1,930.986 ns |     24.6587 ns |     23.0658 ns |  17.11 |    0.42 |    9 | 0.0210 |     272 B |          NA |
|                                          |             |                 |                |                |                |        |         |      |        |           |             |
| GetFolderById_Dictionary                 | 1000        | 10              |       3.175 ns |      0.1056 ns |      0.0987 ns |  0.003 |    0.00 |    1 |      - |         - |          NA |
| FolderExists_Dictionary                  | 1000        | 10              |       5.050 ns |      0.1140 ns |      0.1171 ns |  0.004 |    0.00 |    2 |      - |         - |          NA |
| GetFolderByPath_Dictionary               | 1000        | 10              |       7.506 ns |      0.1625 ns |      0.1441 ns |  0.006 |    0.00 |    3 |      - |         - |          NA |
| GetAssetByFolderIdAndFileName_Dictionary | 1000        | 10              |      11.623 ns |      0.1773 ns |      0.1481 ns |  0.010 |    0.00 |    4 |      - |         - |          NA |
| GetAssetsByFolderId_Dictionary           | 1000        | 10              |      49.879 ns |      0.9473 ns |      0.8861 ns |  0.041 |    0.00 |    5 | 0.0108 |     136 B |          NA |
| GetFolderById_List                       | 1000        | 10              |     344.557 ns |      5.0522 ns |      6.9156 ns |  0.284 |    0.01 |    6 |      - |         - |          NA |
| GetFolderByPath_List                     | 1000        | 10              |   1,212.142 ns |     12.0411 ns |     11.2633 ns |  1.000 |    0.01 |    7 |      - |         - |          NA |
| FolderExists_List                        | 1000        | 10              |   1,215.307 ns |     20.1387 ns |     23.1917 ns |  1.003 |    0.02 |    7 |      - |         - |          NA |
| GetAssetByFolderIdAndFileName_List       | 1000        | 10              |   3,923.685 ns |     77.7537 ns |     76.3645 ns |  3.237 |    0.07 |    8 |      - |         - |          NA |
| GetAssetsByFolderId_List                 | 1000        | 10              |  20,317.241 ns |    290.3925 ns |    271.6333 ns | 16.763 |    0.26 |    9 |      - |     272 B |          NA |
|                                          |             |                 |                |                |                |        |         |      |        |           |             |
| GetFolderById_Dictionary                 | 10000       | 10              |       2.769 ns |      0.1027 ns |      0.2075 ns |  0.000 |    0.00 |    1 |      - |         - |          NA |
| FolderExists_Dictionary                  | 10000       | 10              |       6.919 ns |      0.1604 ns |      0.1716 ns |  0.000 |    0.00 |    2 |      - |         - |          NA |
| GetFolderByPath_Dictionary               | 10000       | 10              |       7.558 ns |      0.1825 ns |      0.1618 ns |  0.001 |    0.00 |    3 |      - |         - |          NA |
| GetAssetByFolderIdAndFileName_Dictionary | 10000       | 10              |      13.387 ns |      0.3102 ns |      0.2902 ns |  0.001 |    0.00 |    4 |      - |         - |          NA |
| GetAssetsByFolderId_Dictionary           | 10000       | 10              |      48.795 ns |      0.9922 ns |      0.9745 ns |  0.003 |    0.00 |    5 | 0.0108 |     136 B |          NA |
| GetFolderById_List                       | 10000       | 10              |   7,743.375 ns |    154.7936 ns |    158.9617 ns |  0.522 |    0.01 |    6 |      - |         - |          NA |
| GetFolderByPath_List                     | 10000       | 10              |  14,836.970 ns |    283.6088 ns |    291.2453 ns |  1.000 |    0.03 |    7 |      - |         - |          NA |
| FolderExists_List                        | 10000       | 10              |  14,972.692 ns |    298.6068 ns |    498.9049 ns |  1.010 |    0.04 |    7 |      - |         - |          NA |
| GetAssetByFolderIdAndFileName_List       | 10000       | 10              | 134,086.839 ns |  2,368.2016 ns |  1,977.5556 ns |  9.041 |    0.22 |    8 |      - |         - |          NA |
| GetAssetsByFolderId_List                 | 10000       | 10              | 622,716.697 ns | 12,334.9179 ns | 30,718.2282 ns | 41.986 |    2.21 |    9 |      - |     272 B |          NA |